### PR TITLE
fix: encode `filters` param correctly to get file list

### DIFF
--- a/src/components/Task.vue
+++ b/src/components/Task.vue
@@ -69,9 +69,9 @@ import { CircleX } from '@vicons/tabler'
     http.get('https://api-drive.mypikpak.com/drive/v1/tasks', {
       params: {
         type: 'offline',
-        filters: {
+        filters: JSON.stringify({
           "phase": {"eq": "PHASE_TYPE_RUNNING"}
-        },
+        }),
         page_token: pageToken.value || undefined,
         thumbnail_size: 'SIZE_LARGE',
         with: 'reference_resource'

--- a/src/views/list.vue
+++ b/src/views/list.vue
@@ -503,7 +503,7 @@ import axios from 'axios';
         with_audit: true,
         page_token: pageToken.value || undefined,
         limit: 100,
-        filters: filters
+        filters: JSON.stringify(filters)
       }
     })
       .then((res:any) => {
@@ -985,10 +985,10 @@ import axios from 'axios';
         thumbnail_size: 'SIZE_LARGE',
         with_audit: true,
         page_token: page || undefined,
-        filters: {
+        filters: JSON.stringify({
           "phase": {"eq": "PHASE_TYPE_COMPLETE"},
           "trashed":{"eq":false}
-        }
+        })
       }
     })
     const {files, next_page_token} = res.data

--- a/src/views/trash.vue
+++ b/src/views/trash.vue
@@ -147,10 +147,10 @@ import { CircleX, CornerUpLeftDouble } from '@vicons/tabler'
         thumbnail_size: 'SIZE_LARGE',
         with_audit: true,
         page_token: pageToken.value || undefined,
-        filters: {
+        filters: JSON.stringify({
           "phase": {"eq": "PHASE_TYPE_COMPLETE"},
-          "trashed":{"eq":true}
-        }
+          "trashed": {"eq": true}
+        })
       }
     })
       .then((res:any) => {


### PR DESCRIPTION
以回收站为例，官方网页版调用接口的参数是
`
thumbnail_size=SIZE_MEDIUM&limit=100&parent_id=%2A&with_audit=true&filters=%7B%22trashed%22%3A%7B%22eq%22%3Atrue%7D%2C%22phase%22%3A%7B%22eq%22%3A%22PHASE_TYPE_COMPLETE%22%7D%7D
`

解码后得到:
`
'thumbnail_size=SIZE_MEDIUM&limit=100&parent_id=*&with_audit=true&filters={"trashed":{"eq":true},"phase":{"eq":"PHASE_TYPE_COMPLETE"}}'
`

可以看到`filters`应当是JSON字符串的形式